### PR TITLE
Add prepublish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "test": "npm run lint && npm run test:src",
     "build": "babel src --out-dir lib --ignore spec.js",
     "projectz": "projectz compile",
-    "compile": "npm run lint && npm run build && npm run projectz"
+    "compile": "npm run lint && npm run build && npm run projectz",
+    "prepublish": "npm run build"
   },
   "engines": {
     "node": ">=6.9.1"


### PR DESCRIPTION
In the last release, `lib/` wasn't included, which breaks the tests.

This will prevent that from happening again. Could you release a new version after this?